### PR TITLE
add password reset and email confirmation using SendGrid

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -53,4 +53,9 @@
     Don’t have an account?
     <a href="{% url 'register' %}">Register here</a>.
 </p>
+
+<p class="mt-3">
+    <a href="{% url 'password_reset' %}">Forgot your password?</a>
+</p>
+
 {% endblock %}

--- a/accounts/templates/accounts/password_reset.html
+++ b/accounts/templates/accounts/password_reset.html
@@ -1,0 +1,19 @@
+{% extends "core/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2 class="mb-3">Reset your password</h2>
+    <p>Enter the email address associated with your account and we’ll send you a link to reset your password.</p>
+
+    <form method="post">
+        {% csrf_token %}
+        {{ form|crispy }}
+        <button type="submit" class="btn btn-primary mt-2">Send reset link</button>
+    </form>
+
+    <p class="mt-3">
+        <a href="{% url 'login' %}">Back to login</a>
+    </p>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_reset_complete.html
+++ b/accounts/templates/accounts/password_reset_complete.html
@@ -1,0 +1,12 @@
+{% extends "core/base.html" %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Password reset complete</h2>
+    <p>Your password has been successfully reset. You can now log in with your new password.</p>
+
+    <p class="mt-3">
+        <a class="btn btn-primary" href="{% url 'login' %}">Go to login</a>
+    </p>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_reset_confirm.html
+++ b/accounts/templates/accounts/password_reset_confirm.html
@@ -1,0 +1,19 @@
+{% extends "core/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2 class="mb-3">Choose a new password</h2>
+
+    {% if validlink %}
+        <form method="post">
+            {% csrf_token %}
+            {{ form|crispy }}
+            <button type="submit" class="btn btn-primary mt-2">Reset password</button>
+        </form>
+    {% else %}
+        <p>The password reset link is invalid or has expired.</p>
+        <p><a href="{% url 'password_reset' %}">Request a new password reset link</a></p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_reset_done.html
+++ b/accounts/templates/accounts/password_reset_done.html
@@ -1,0 +1,12 @@
+{% extends "core/base.html" %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Password reset email sent</h2>
+    <p>If an account exists with the email you entered, you’ll receive a password reset link shortly.</p>
+
+    <p class="mt-3">
+        <a href="{% url 'login' %}">Return to login</a>
+    </p>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_reset_email.html
+++ b/accounts/templates/accounts/password_reset_email.html
@@ -1,0 +1,16 @@
+{% autoescape off %}
+Hi {{ user.username }},
+
+You requested a password reset for your Garden Timekeeper account.
+
+This reset link is specifically for the account with the username: **{{ user.username }}**
+
+Click the link below to choose a new password:
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+If you didn’t request this, you can safely ignore the email.
+
+Thanks,
+The Garden Timekeeper Team
+{% endautoescape %}

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -8,6 +8,7 @@ between authentication logic and the rest of the application.
 
 
 from django.urls import path
+from django.contrib.auth import views as auth_views
 from . import views
 
 urlpatterns = [
@@ -16,4 +17,30 @@ urlpatterns = [
     path('logout/', views.logout_view, name='logout'),
     path("delete/", views.delete_account, name="delete_account"),
     path("settings/", views.account_settings, name="account_settings"),
+    
+    # Password Reset (Django’s built‑in flow)
+    path("password-reset/",
+         auth_views.PasswordResetView.as_view(
+             template_name="accounts/password_reset.html"
+         ),
+         name="password_reset"),
+
+    path("password-reset/done/",
+         auth_views.PasswordResetDoneView.as_view(
+             template_name="accounts/password_reset_done.html"
+         ),
+         name="password_reset_done"),
+
+    path("reset/<uidb64>/<token>/",
+         auth_views.PasswordResetConfirmView.as_view(
+             template_name="accounts/password_reset_confirm.html"
+         ),
+         name="password_reset_confirm"),
+
+    path("reset/done/",
+         auth_views.PasswordResetCompleteView.as_view(
+             template_name="accounts/password_reset_complete.html"
+         ),
+         name="password_reset_complete"),
+
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -155,3 +155,5 @@ def account_settings(request):
     Allows the user to delete their account or reset their password.
     """
     return render(request, "accounts/account_settings.html")
+
+

--- a/garden_timekeeper/settings.py
+++ b/garden_timekeeper/settings.py
@@ -217,3 +217,20 @@ SUMMERNOTE_CONFIG = {
 AUTHENTICATION_BACKENDS = [
     'core.auth_backends.CaseInsensitiveUsernameBackend',
 ]
+
+# prints password reset emails to the terminal for debugging.
+# EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# Email settings (production uses SendGrid via environment variables)
+EMAIL_BACKEND = os.getenv(
+    "EMAIL_BACKEND",
+    "django.core.mail.backends.console.EmailBackend"
+)
+
+EMAIL_HOST = os.getenv("EMAIL_HOST", "")
+EMAIL_PORT = int(os.getenv("EMAIL_PORT", 587))
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True") == "True"
+
+DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "webmaster@localhost")


### PR DESCRIPTION
Add custom password reset email template
This update replaces Django’s default password reset email with a custom template that includes the user’s username. This improves clarity for cases where multiple accounts share the same email address.

Changes included:

Added templates/registration/password_reset_email.html

Customised email content to show the username and a clearer reset link

No changes to backend logic or views

This ensures users always know which account the reset link applies to, while keeping the rest of the password reset flow unchanged.