### PR TITLE
add account management pages

### DIFF
--- a/accounts/templates/accounts/account_edit.html
+++ b/accounts/templates/accounts/account_edit.html
@@ -1,0 +1,23 @@
+{% extends "core/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2 class="mb-3">Update Account Details for: "{{ request.user.username }}"</h2>
+
+    <form method="post" novalidate>
+        {% csrf_token %}
+        {{ form|crispy }}
+
+        <button type="submit" class="btn btn-primary mt-3">
+            Save Changes
+        </button>
+    </form>
+
+    <p class="mt-3">
+    <a href="{% url 'password_change' %}">Change your password</a>
+    </p>
+
+
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/account_settings.html
+++ b/accounts/templates/accounts/account_settings.html
@@ -14,9 +14,9 @@
                     <p class="mb-1"><strong>Username:</strong> {{ request.user.username }}</p>
                     <p class="mb-3"><strong>Email:</strong> {{ request.user.email }}</p>
 
-                    <!-- Placeholder for future features -->
+                    <!-- Update account details link -->
                     <p class="text-muted small">
-                        More account options coming soon.
+                        <a href="{% url 'update_account' %}">Update account details</a>
                     </p>
                 </div>
             </div>

--- a/accounts/templates/accounts/password_edit.html
+++ b/accounts/templates/accounts/password_edit.html
@@ -1,0 +1,14 @@
+{% extends "core/base.html" %}
+{% load crispy_forms_tags %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Change Password</h2>
+
+    <form method="post">
+        {% csrf_token %}
+        {{ form|crispy }}
+        <button class="btn btn-primary mt-3" type="submit">Update Password</button>
+    </form>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/password_edit_done.html
+++ b/accounts/templates/accounts/password_edit_done.html
@@ -1,0 +1,8 @@
+{% extends "core/base.html" %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Password Updated</h2>
+    <p>Your password has been successfully changed.</p>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/register.html
+++ b/accounts/templates/accounts/register.html
@@ -23,8 +23,27 @@ Registration page for Garden Timekeeper.
     <div class="mb-3">
         {{ form.username.label_tag }}
         {{ form.username }}
+        <div class="form-text">No spaces allowed in your username.</div>
         {% if form.username.errors %}
             <div class="text-danger small">{{ form.username.errors.0 }}</div>
+        {% endif %}
+    </div>
+
+    {# First name #}
+    <div class="mb-3">
+        {{ form.first_name.label_tag }}
+        {{ form.first_name }}
+        {% if form.first_name.errors %}
+            <div class="text-danger small">{{ form.first_name.errors.0 }}</div>
+        {% endif %}
+    </div>
+
+    {# Last name #}
+    <div class="mb-3">
+        {{ form.last_name.label_tag }}
+        {{ form.last_name }}
+        {% if form.last_name.errors %}
+            <div class="text-danger small">{{ form.last_name.errors.0 }}</div>
         {% endif %}
     </div>
 

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path('logout/', views.logout_view, name='logout'),
     path("delete/", views.delete_account, name="delete_account"),
     path("settings/", views.account_settings, name="account_settings"),
-    
+
     # Password Reset (Django’s built‑in flow)
     path("password-reset/",
          auth_views.PasswordResetView.as_view(
@@ -43,4 +43,20 @@ urlpatterns = [
          ),
          name="password_reset_complete"),
 
+    # Update Account
+    path("account/", views.update_account, name="update_account"),
+
+
+    # Password change (for logged-in users)
+    path("password/change/",
+         auth_views.PasswordChangeView.as_view(
+             template_name="accounts/password_edit.html"
+         ),
+         name="password_change"),
+
+    path("password/change/done/",
+         auth_views.PasswordChangeDoneView.as_view(
+             template_name="accounts/password_edit_done.html"
+         ),
+         name="password_change_done"),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -14,8 +14,8 @@ their Garden Timekeeper accounts.
 from django.shortcuts import render, redirect
 from django.contrib.auth import login, logout
 from django.contrib import messages
-from .forms import RegistrationForm, LoginForm
 from django.contrib.auth.decorators import login_required
+from .forms import RegistrationForm, LoginForm, AccountUpdateForm
 
 
 def login_view(request):
@@ -108,7 +108,10 @@ def register_view(request):
         if form.is_valid():
             user = form.save()
             login(request, user)
-            messages.success(request, "Account created successfully!")
+            messages.success(
+                request,
+                f"Account created successfully for: '{user.username}'!"
+            )
             return redirect("home")
 
         # Form is invalid — custom messages are already handled by the form
@@ -157,3 +160,29 @@ def account_settings(request):
     return render(request, "accounts/account_settings.html")
 
 
+@login_required
+def update_account(request):
+    """
+    Allow the logged-in user to update their account details.
+
+    Currently supports:
+    - Updating email address
+
+    Future-ready for:
+    - First name
+    - Last name
+    - Additional profile fields
+    """
+    if request.method == "POST":
+        form = AccountUpdateForm(request.POST, instance=request.user)
+        if form.is_valid():
+            form.save()
+            messages.success(
+                request,
+                "Your account details have been updated."
+            )
+            return redirect("account_settings")
+    else:
+        form = AccountUpdateForm(instance=request.user)
+
+    return render(request, "accounts/account_edit.html", {"form": form})


### PR DESCRIPTION
1. Added full Account Editing functionality
Introduced AccountUpdateForm to allow users to update:

First name

Last name

Email address

Username intentionally excluded from editing to preserve identity stability.

Updated view (update_account) to use the new form.

Renamed template to account_edit.html for naming consistency.

Added contextual header showing the logged‑in user’s username.

2. Improved Registration Form
Added first_name and last_name fields to RegistrationForm.

Updated registration template to render the new fields with Bootstrap styling.

Added helper text and validation to clarify that usernames cannot contain spaces.

Registration success message now includes the new user’s username.

3. Added Password Change Flow for Logged‑In Users
Implemented Django’s built‑in password change views:

password_change

password_change_done

Added templates for both views with consistent Bootstrap styling.

Added a “Change your password” link to the account edit page.

4. Template & Naming Consistency
Renamed update_account.html → account_edit.html.

Ensured all account‑related templates extend core/base.html.

