### PR TITLE
issue-88 add images to notes

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from .models import GardenBed, Plant, PlantTask
 from crispy_forms.helper import FormHelper
-from django_summernote.widgets import SummernoteInplaceWidget
+from django_summernote.widgets import SummernoteWidget
 
 
 # -----------------------------------------------------
@@ -68,7 +68,10 @@ class PlantForm(forms.ModelForm):
                 attrs={"class": "form-control", "type": "date"}
             ),
             "bed": forms.Select(attrs={"class": "form-select"}),
-            "notes": SummernoteInplaceWidget(),
+            "notes": SummernoteWidget(
+                attrs={'summernote': {'airMode': False}}
+                ),
+
         }
 
     def __init__(self, *args, **kwargs):
@@ -119,5 +122,7 @@ class PlantTaskForm(forms.ModelForm):
         }
         fields = "__all__"
         widgets = {
-            "notes": SummernoteInplaceWidget(),
+            'notes': SummernoteWidget(
+                attrs={'summernote': {'airMode': False}}
+            ),
         }

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -9,16 +9,6 @@
     <meta name="author" content="Mark Rosevere">
 
     <title>{% block title %}Garden Timekeeper{% endblock %}</title>
-
-    <!-- jQuery required for Summernote -->
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-
-    <!-- Summernote CSS as not using iframe -->
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote-lite.min.css" rel="stylesheet">
-
-    <!-- Summernote JS as not using iframe -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote-lite.min.js"></script>
-
    
     <!-- Bootstrap 5 -->
     <link
@@ -28,15 +18,15 @@
       crossorigin="anonymous"
     >
 
+    <!-- Font Awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    
     <!-- Custom static CSS -->
     {% load static %}
     <link rel="stylesheet" href="{% static 'assets/css/style.css' %}" />
 
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    
-    <!-- Custom static JS -->
-    <script src="{% static 'assets/js/style.js' %}"></script>
+    <!-- Summernote CSS (full version, required for image uploads) -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote.min.css" rel="stylesheet">
 
     <!-- favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/static/assets/images/favicon/apple-touch-icon.png">
@@ -127,11 +117,50 @@
       <p class="mb-0 text-muted">Garden Timekeeper © {% now "Y" %}</p>
     </footer>
 
+    <!-- ===================================== -->
+    <!-- ==     JavaScript Scripts          == -->
+    <!-- ===================================== -->
+    
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 
-    <!-- Custom JS -->
+   <!-- ============================================================
+     Summernote + Dependencies
+     ------------------------------------------------------------
+     These scripts must load in this exact order:
+
+       1. jQuery                → Summernote depends on it
+       2. jQuery UI             → required by File Upload plugin
+       3. jQuery File Upload    → Summernote uses .fileupload()
+       4. Summernote JS         → full version (NOT lite)
+       5. Your custom JS        → must run AFTER all libraries
+
+     IMPORTANT:
+       • Loading these in the wrong order causes "$ is not defined"
+         or "$.fileupload is not a function".
+       • Summernote-Lite does NOT support image uploads.
+   ============================================================ -->
+
+    <!-- jQuery (required by Summernote) -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+
+    <!-- jQuery UI (required by the File Upload plugin) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
+
+    <!-- jQuery File Upload dependencies -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-file-upload/10.32.0/js/vendor/jquery.ui.widget.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/blueimp-file-upload/10.32.0/js/jquery.fileupload.js"></script>
+
+    <!-- Full Summernote JS (supports image uploads) -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.20/summernote.min.js"></script>
+
+   <!-- End of Summernote dependencies  -->
+
+    <!-- custom JS (must load AFTER all other dependencies) -->
     <script src="{% static 'assets/js/style.js' %}"></script>
-    
+
+    <!-- Page-specific JS (e.g., Summernote init code) -->
+    {% block extra_js %}{% endblock %}
+
   </body>
 </html>

--- a/core/templates/core/tasks/task_form.html
+++ b/core/templates/core/tasks/task_form.html
@@ -81,3 +81,20 @@
 
 </div>
 {% endblock %}
+
+{% block extra_js %}
+<script>
+    $(function() {
+        $('#id_notes').summernote({
+            height: 200,
+            toolbar: [
+                ['style', ['style']],  // headings dropdown
+                ['font', ['bold', 'italic', 'underline', 'clear']],
+                ['para', ['ul', 'ol', 'paragraph']],
+                ['insert', ['link', 'picture']],  // image upload enabled
+                ['view', ['fullscreen']]
+            ]
+        });
+    });
+</script>
+{% endblock %}

--- a/garden_timekeeper/settings.py
+++ b/garden_timekeeper/settings.py
@@ -193,17 +193,24 @@ SUMMERNOTE_CONFIG = {
     # (disable iframe so I can use standard CSS styling)
     'iframe': False,
 
-    # Set the toolbar layout
+    # Store Summernote uploads (images, files) in Cloudinary
+    "attachment_storage": "cloudinary_storage.storage.MediaCloudinaryStorage",
+
+    # Optional: folder prefix in Cloudinary
+    "attachment_upload_to": "summernote",
+
+    # Set the toolbar layout to be restricted so it takes less room
+    #     ['style', ['bold', 'italic', 'underline', 'clear']],
+    #     ['para', ['ul', 'ol', 'paragraph']],
+    #     ['insert', ['link', 'picture']],
+    #     ['view', ['fullscreen']],
+    # ],
     'toolbar': [
-        ['style', ['bold', 'italic', 'underline', 'clear']],
+        ['style', ['style']],  # includes headings
         ['para', ['ul', 'ol', 'paragraph']],
-        # removed 'picture' see issue-123
-        ['insert', ['link']],
+        ['insert', ['link', 'picture']],
         ['view', ['fullscreen']],
     ],
-
-    # Disable file uploads (local images)
-    'disable_upload': True,
 
     # Optional: restrict allowed tags for safety
     'allowed_tags': [


### PR DESCRIPTION
1. Replaced SummernoteInplaceWidget with SummernoteWidget
- Removed SummernoteInplaceWidget, which injected inline JS that executed before jQuery.
- Standardized on SummernoteWidget(airMode=False) for both Plant and Task forms.
- Eliminated $ is not defined errors caused by premature auto‑initialisation.

2. Added explicit Summernote initialization via {% block extra_js %}
- Moved all Summernote init logic into task_form.html inside extra_js.
- Ensures Summernote loads after jQuery, jQuery UI, FileUpload, and Summernote JS.
- Provides full control over toolbar, height, and behaviour.

3. Cleaned up script order in base.html
- Removed duplicate style.js load.
- Ensured all JS libraries load in the correct dependency order:
- jQuery
- jQuery UI
- File Upload plugin
- Summernote
- Custom JS
- Page‑specific JS