### PR TITLE
fix issue-143 remove self.helper.disable_csrf = True

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -87,6 +87,7 @@ class PlantForm(forms.ModelForm):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
 
+        # Restrict beds to the current user
         if user is not None:
             self.fields["bed"].queryset = GardenBed.objects.filter(owner=user)
         else:
@@ -95,11 +96,7 @@ class PlantForm(forms.ModelForm):
         # Crispy helper (minimal setup for consistency with Task form)
         self.helper = FormHelper()
         self.helper.form_tag = False
-        self.helper.disable_csrf = True
         self.helper.include_media = False
-
-        # Restrict beds to the current user
-        self.fields["bed"].queryset = GardenBed.objects.filter(owner=user)
 
 
 # -----------------------------------------------------


### PR DESCRIPTION
When CSRF is disabled on a form that contains a file upload widget (CloudinaryField or SummernoteWidget), Django’s CSRF middleware rejects the request before the view runs, returning 400 Bad Request.

Solution:
Remove "self.helper.disable_csrf = True"