### PR TITLE
fix issue-191 Summernote menu items

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -141,10 +141,18 @@
     </script>
 
     <!-- custom JS (must load AFTER all other dependencies) -->
-    <script src="{% static 'assets/js/style.js' %}"></script>
+    <script src="{% static 'assets/js/script.js' %}"></script>
 
     <!-- Page-specific JS (e.g., Summernote init code) -->
-    {% block extra_js %}{% endblock %}
+    {% block extra_js %}
+    <script>
+        $(function() {
+            if ($('#id_notes').length) {
+                initSummernoteWithBootstrap5('#id_notes');
+            }
+        });
+    </script>
+    {% endblock %}
 
   </body>
 </html>

--- a/core/templates/core/plants/plant_create.html
+++ b/core/templates/core/plants/plant_create.html
@@ -74,20 +74,3 @@
 
 </div>
 {% endblock %}
-
-{% block extra_js %}
-<script>
-    $(function() {
-        $('#id_notes').summernote({
-            height: 200,
-            toolbar: [
-                ['style', ['style']],
-                ['font', ['bold', 'italic', 'underline', 'clear']],
-                ['para', ['ul', 'ol', 'paragraph']],
-                ['insert', ['link', 'picture']],
-                ['view', ['fullscreen']]
-            ]
-        });
-    });
-</script>
-{% endblock %}

--- a/core/templates/core/tasks/task_form.html
+++ b/core/templates/core/tasks/task_form.html
@@ -81,20 +81,3 @@
 
 </div>
 {% endblock %}
-
-{% block extra_js %}
-<script>
-    $(function() {
-        $('#id_notes').summernote({
-            height: 200,
-            toolbar: [
-                ['style', ['style']],  // headings dropdown
-                ['font', ['bold', 'italic', 'underline', 'clear']],
-                ['para', ['ul', 'ol', 'paragraph']],
-                ['insert', ['link', 'picture']],  // image upload enabled
-                ['view', ['fullscreen']]
-            ]
-        });
-    });
-</script>
-{% endblock %}

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -265,6 +265,32 @@ th.sortable.sort-desc i {
     display: block;
 }
 
+/* Custom styling for Summernote toolbar buttons */
+.note-editor .note-btn.active,
+.note-editor .note-btn:active {
+    background-color: var(--bs-primary-bg-subtle, #d0e3ff) !important;
+    border-color: var(--bs-primary-border-subtle, #9ec5fe) !important;
+    color: var(--bs-primary-text, #084298) !important;
+    box-shadow: inset 0 2px 4px rgba(0,0,0,.15);
+}
+
+/* Fix Summernote fullscreen mode under Bootstrap 5 */
+.note-editor.note-frame.fullscreen {
+    position: fixed !important;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100% !important;
+    height: 100% !important;
+    z-index: 1050 !important; /* above modals */
+    background: #fff !important;
+}
+
+.note-editor.note-frame.fullscreen .note-editable {
+    height: calc(100% - 50px) !important; /* leave room for toolbar */
+    overflow-y: auto !important;
+}
 
 
 /* ============================================================== */

--- a/static/assets/js/script.js
+++ b/static/assets/js/script.js
@@ -3,7 +3,7 @@
 
 
 // Confirm the JS bundle is loaded
-console.log("Garden Timekeeper JS loaded");
+// console.log("Garden Timekeeper JS loaded");
 
 
 // ------------------------------------------------------------
@@ -149,3 +149,83 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 });
+
+
+// -------------------------------------------------------------
+// 4. Summernote Initialiser (Bootstrap 5 Compatible)
+//
+// This helper function applies a fully‑patched Summernote editor
+// to any field selector. Summernote was originally built for
+// Bootstrap 3/4, so Bootstrap 5 breaks several behaviours:
+//   - Dropdowns no longer open/close correctly
+//   - Tooltips fail to initialise
+//   - The Style dropdown stays open after selection
+//   - Heading 2 does not apply due to a Summernote quirk
+//
+// This function:
+//   • Initialises Summernote with a consistent toolbar
+//   • Rewrites legacy data‑toggle attributes to Bootstrap 5
+//   • Re‑initialises tooltips and dropdowns using Bootstrap 5 APIs
+//   • Forces the Style dropdown to close after selecting an option
+//   • Overrides the broken H2 behaviour with a reliable formatBlock call
+//
+// Usage:
+//   initSummernoteWithBootstrap5('#id_notes');
+//   initSummernoteWithBootstrap5('#id_task_notes', 300);
+//
+// This keeps all Summernote fixes in one place and ensures that
+// any page using a notes field behaves consistently.
+// -------------------------------------------------------------
+function initSummernoteWithBootstrap5(selector, height = 200) {
+    $(selector).summernote({
+        height: height,
+        toolbar: [
+            ['style', ['style']],
+            ['font', ['bold', 'italic', 'underline', 'clear']],
+            ['para', ['ul', 'ol', 'paragraph']],
+            ['insert', ['link', 'picture']],
+            ['view', ['fullscreen']]
+        ],
+        callbacks: {
+            onInit: function() {
+                const $editor = $(selector).next('.note-editor');
+
+                // Fix dropdowns
+                $editor.find('[data-toggle="dropdown"]')
+                    .attr('data-bs-toggle', 'dropdown')
+                    .removeAttr('data-toggle');
+
+                // Fix tooltips
+                $editor.find('[data-toggle="tooltip"]')
+                    .attr('data-bs-toggle', 'tooltip')
+                    .removeAttr('data-toggle');
+
+                // Reinitialise Bootstrap tooltips
+                $editor.find('[data-bs-toggle="tooltip"]').each(function() {
+                    new bootstrap.Tooltip(this);
+                });
+
+                // Reinitialise Bootstrap dropdowns
+                $editor.find('[data-bs-toggle="dropdown"]').each(function() {
+                    new bootstrap.Dropdown(this);
+                });
+
+                // Close Style dropdown after selection
+                $editor.find('.note-dropdown-menu a').on('click', function () {
+                    const dropdownButton = $(this)
+                        .closest('.note-btn-group')
+                        .find('[data-bs-toggle="dropdown"]')[0];
+
+                    const dropdown = bootstrap.Dropdown.getInstance(dropdownButton);
+                    if (dropdown) dropdown.hide();
+                });
+
+                // Fix Heading 2 not applying
+                $editor.find('.note-dropdown-menu a[data-value="h2"]').on('click', function (e) {
+                    e.preventDefault();
+                    $(selector).summernote('formatBlock', 'H2');
+                });
+            }
+        }
+    });
+}


### PR DESCRIPTION
Renamed style.js to script.js
Moved custom initiation of summernotes from templates to the global script.js file.
Fixed issues with Summernotes menu items not working with Bootstrap 5.