### PR TITLE
fix issue-210 image overflow on smallest screen

### DIFF
--- a/core/templates/core/plants/plant_detail.html
+++ b/core/templates/core/plants/plant_detail.html
@@ -107,7 +107,7 @@
         <div class="col-12 col-lg-4">
             <div class="card shadow-sm h-100">
                 <div class="card-header">Plant Image</div>
-                <div class="card-body d-flex justify-content-center align-items-center">
+                <div class="card-body d-flex justify-content-center align-items-center plant-image">
                     {% if plant.image %}
                         <img
                             src="{{ plant.image.url }}"

--- a/static/assets/css/style.css
+++ b/static/assets/css/style.css
@@ -292,6 +292,14 @@ th.sortable.sort-desc i {
     overflow-y: auto !important;
 }
 
+/* Plant Image - stop overflow on smallest screens*/
+.plant-image img {
+    width: 100%;
+    height: auto;
+    max-width: 300px; /* keeps  intended size on larger screens */
+    object-fit: cover;
+    display: block;
+}
 
 /* ============================================================== */
 /* ==              Media Queries                               == */


### PR DESCRIPTION
Fix image overflow on the plant details page on the smallest screen.
Add CSS class and CSS to resolve.